### PR TITLE
Add other supported statistics with the new RocksDB version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Outputs CSV-files and pgfplot of write, compaction and stall statistics.
 - p99
 - p75
 - p50
+- L0_P99.99
+- L1_P99.99
+- L2_P99.99
+- L3_P99.99
+- L4_P99.99
+- L5_P99.99
+- L6_P99.99
+- L7_P99.99
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ Outputs CSV-files and pgfplot of write, compaction and stall statistics.
 - cumulative_stall
 - interval_compaction
 - cumulative_compaction
+- cumulative_wal
+- interval_wal
+- cumulative_flush
+- interval_flush
+- add_file_cumulative
+- add_file_interval
+- delays_with_ongoing_compaction
+- stops_with_ongoing_compaction
+- l0_file_count_limit_delays
+- l0_file_count_limit_stops
+- memtable_limit_delays
+- memtable_limit_stops
+- pending_compaction_bytes_delays
+- pending_compaction_bytes_stops
+- total_delays
+- total_stops
+- l0_files
+- l0_size
+- num_running_compactions
+- num_running_flushes
+- p99.99
+- p99.9
+- p99
+- p75
+- p50
 
 ## Usage
 

--- a/rocksdb_statistics/rocksdb_statistics.py
+++ b/rocksdb_statistics/rocksdb_statistics.py
@@ -149,6 +149,38 @@ class Statistics:
                 "name": "P50",
                 "regex": "P50.*?(\d*\.\d*)\sP", 
             },  
+            "L0_P99.99": {
+                "name": "L0 P99.99",
+                "regex": "Level\s0\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)", 
+            },  
+            "L1_P99.99": {
+                "name": "L1 P99.99",
+                "regex": "Level\s1\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)", 
+            },  
+            "L2_P99.99": {
+                "name": "L2 P99.99",
+                "regex": "Level\s2\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)",
+            }, 
+            "L3_P99.99": {
+                "name": "L3 P99.99",
+                "regex": "Level\s3\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)",
+            }, 
+            "L4_P99.99": {
+                "name": "L4 P99.99",
+                "regex": "Level\s4\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)",
+            }, 
+            "L5_P99.99": {
+                "name": "L5 P99.99",
+                "regex": "Level\s5\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)",
+            }, 
+            "L6_P99.99": {
+                "name": "L6 P99.99",
+                "regex": "Level\s6\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)",
+            }, 
+            "L7_P99.99": {
+                "name": "L7 P99.99",
+                "regex": "Level\s7\sread\slatency.*?\s.*?\s.*?\s.*?\sP99\.99.*?(\d*\.\d*)",
+            },
         }
 
         self.legend_list: list[str] = []

--- a/rocksdb_statistics/rocksdb_statistics.py
+++ b/rocksdb_statistics/rocksdb_statistics.py
@@ -49,6 +49,106 @@ class Statistics:
                 "name": "Interval Compaction",
                 "regex": "Interval\scompaction.*?(\d*\.\d*)\sMB\/s",
             },
+            "cumulative_wal": {
+                "name": "Cumulative WAL",
+                "regex": "Cumulative\sWAL.*?(\d*\.\d*)\swrites", 
+            },
+            "interval_wal": {
+                "name": "Interval WAL",
+                "regex": "Interval\sWAL.*?(\d*\.\d*)\swrites", 
+            }, 
+            "cumulative_flush": {
+                "name": "Cumulative Flush",
+                "regex": "Flush.*?(\d*\.\d*),", 
+            }, 
+            "interval_flush": {
+                "name": "Interval Flush",
+                "regex": "Flush.*?interval\s(\d*\.\d*)", 
+            }, 
+            "add_file_cumulative": {
+                "name": "AddFile (GB) Cumulative",
+                "regex": "AddFile\(GB\).*?\s(\d*\.\d*),", 
+            }, 
+            "add_file_interval": {
+                "name": "AddFile (GB) Interval",
+                "regex": "AddFile\(GB\).*?interval\s(\d*\.\d*)", 
+            }, 
+            "delays_with_ongoing_compaction": {
+                "name": "cf-l0-file-count-limit-delays-with-ongoing-compaction",
+                "regex": "cf-l0-file-count-limit-delays-with-ongoing-compaction.*?(\d),", 
+            }, 
+            "stops_with_ongoing_compaction": {
+                "name": "cf-l0-file-count-limit-stops-with-ongoing-compaction",
+                "regex": "cf-l0-file-count-limit-stops-with-ongoing-compaction.*?(\d),", 
+            }, 
+            "l0_file_count_limit_delays": {
+                "name": "l0-file-count-limit-delays",
+                "regex": "l0-file-count-limit-delays\:.*?(\d),", 
+            }, 
+            "l0_file_count_limit_stops": {
+                "name": "l0-file-count-limit-stops",
+                "regex": "l0-file-count-limit-stops\:.*?(\d),", 
+            }, 
+            "memtable_limit_delays": {
+                "name": "memtable-limit-delays",
+                "regex": "memtable-limit-delays\:.*?(\d),", 
+            }, 
+            "memtable_limit_stops": {
+                "name": "memtable-limit-stops",
+                "regex": "memtable-limit-stops\:.*?(\d),", 
+            }, 
+            "pending_compaction_bytes_delays": {
+                "name": "pending-compaction-bytes-delays",
+                "regex": "pending-compaction-bytes-delays\:.*?(\d),", 
+            }, 
+            "pending_compaction_bytes_stops": {
+                "name": "pending-compaction-bytes-stops",
+                "regex": "pending-compaction-bytes-stops\:.*?(\d),", 
+            }, 
+            "total_delays": {
+                "name": "total-delays",
+                "regex": "total-delays\:.*?(\d),", 
+            }, 
+            "total_stops": {
+                "name": "total-stops",
+                "regex": "total-stops\:.*?(\d),", 
+            }, 
+            "l0_files": {
+                "name": "L0 Files",
+                "regex": "L0.*?(\d)\/", 
+            }, 
+            "l0_size": {
+                "name": "L0 Size",
+                "regex": "L0.*?(\d*\.\d*)\sMB", 
+            }, 
+            "num_running_compactions": {
+                "name": "num-running-compactions",
+                "regex": "num-running-compactions.*?(\d)", 
+            }, 
+            "num_running_flushes": {
+                "name": "num-running-flushes",
+                "regex": "num-running-flushes.*?(\d)", 
+            },  
+            "p99.99": {
+                "name": "P99.99",
+                "regex": "P99\.99.*?(\d*\.\d*)", 
+            },  
+            "p99.9": {
+                "name": "P99.9",
+                "regex": "P99\.9.*?(\d*\.\d*)\sP", 
+            },  
+            "p99": {
+                "name": "P99",
+                "regex": "P99.*?(\d*\.\d*)\sP", 
+            },  
+            "p75": {
+                "name": "P75",
+                "regex": "P75.*?(\d*\.\d*)\sP", 
+            },  
+            "p50": {
+                "name": "P50",
+                "regex": "P50.*?(\d*\.\d*)\sP", 
+            },  
         }
 
         self.legend_list: list[str] = []


### PR DESCRIPTION
Add cumulative_wal, interval_wal, cumulative_flush, interval_flush, add_file_cumulative, add_file_interval, delays_with_ongoing_compaction, stops_with_ongoing_compaction, l0_file_count_limit_delays, l0_file_count_limit_stops, memtable_limit_delays, memtable_limit_stops, pending_compaction_bytes_delays, pending_compaction_bytes_stops, total_delays, total_stops, l0_files, l0_size, num_running_compactions, num_running_flushes, p99.99, p99.9, p99, p75, p50